### PR TITLE
Adding namespace/ProjectRequest templates and adding jenkins rolebind…

### DIFF
--- a/templates/deploy/template.yml
+++ b/templates/deploy/template.yml
@@ -14,6 +14,10 @@ parameters:
   description: The OpenShift Namespace where the Infographic app will be Deployed
   displayName: Infographic Deployment Namespace
   value: infographic-dev
+- name: BUILD_NAMESPACE
+  description: The OpenShift Namespace where the app will be Built
+  displayName: Pipeline Namespace
+  value: infographic-pipeline
 - name: IMAGE_TAG
   description: The ImageStreamTag for the deployment
   displayName: Image Tag
@@ -122,3 +126,16 @@ objects:
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst
         securityContext: {}
+- kind: RoleBinding
+  apiVersion: v1
+  metadata:
+    name: jenkins_edit
+    namespace: ${NAMESPACE}
+  roleRef:
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: jenkins
+    namespace: ${BUILD_NAMESPACE}
+  userNames:
+  - system:serviceaccount:${BUILD_NAMESPACE}:jenkins

--- a/templates/example/namespace/development.yml
+++ b/templates/example/namespace/development.yml
@@ -1,0 +1,67 @@
+---
+kind: List
+apiVersion: v1
+metadata: {}
+items:
+- apiVersion: v1
+  kind: ProjectRequest
+  metadata:
+    annotations:
+      openshift.io/description: ''
+      openshift.io/display-name: Infographic Development
+    creationTimestamp:
+    name: infographic-dev
+  spec: {}
+  status: {}
+- apiVersion: v1
+  groupNames:
+  - system:serviceaccounts:infographic-dev
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:image-pullers
+    namespace: infographic-dev
+  roleRef:
+    name: system:image-puller
+  subjects:
+  - kind: SystemGroup
+    name: system:serviceaccounts:infographic-dev
+  userNames:
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:image-builders
+    namespace: infographic-dev
+  roleRef:
+    name: system:image-builder
+  subjects:
+  - kind: ServiceAccount
+    name: builder
+  userNames:
+  - system:serviceaccount:infographic-dev:builder
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:deployers
+    namespace: infographic-dev
+  roleRef:
+    name: system:deployer
+  subjects:
+  - kind: ServiceAccount
+    name: deployer
+  userNames:
+  - system:serviceaccount:infographic-dev:deployer
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: edit
+    namespace: infographic-dev
+  roleRef:
+    name: edit
+  subjects:

--- a/templates/example/namespace/pipeline.yml
+++ b/templates/example/namespace/pipeline.yml
@@ -1,0 +1,57 @@
+---
+kind: List
+apiVersion: v1
+metadata: {}
+items:
+- apiVersion: v1
+  kind: ProjectRequest
+  metadata:
+    annotations:
+      openshift.io/description: ''
+      openshift.io/display-name: Infographic Pipeline
+    creationTimestamp:
+    name: infographic-pipeline
+  spec: {}
+  status: {}
+- apiVersion: v1
+  groupNames:
+  - system:serviceaccounts:infographic-pipeline
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:image-pullers
+    namespace: infographic-pipeline
+  roleRef:
+    name: system:image-puller
+  subjects:
+  - kind: SystemGroup
+    name: system:serviceaccounts:infographic-pipeline
+  userNames:
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:image-builders
+    namespace: infographic-pipeline
+  roleRef:
+    name: system:image-builder
+  subjects:
+  - kind: ServiceAccount
+    name: builder
+  userNames:
+  - system:serviceaccount:infographic-pipeline:builder
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:deployers
+    namespace: infographic-pipeline
+  roleRef:
+    name: system:deployer
+  subjects:
+  - kind: ServiceAccount
+    name: deployer
+  userNames:
+  - system:serviceaccount:infographic-pipeline:deployer

--- a/templates/example/namespace/test.yml
+++ b/templates/example/namespace/test.yml
@@ -1,0 +1,69 @@
+---
+kind: List
+apiVersion: v1
+metadata: {}
+items:
+- apiVersion: v1
+  kind: ProjectRequest
+  metadata:
+    annotations:
+      openshift.io/description: ''
+      openshift.io/display-name: Infographic Test
+    creationTimestamp:
+    name: infographic-test
+  spec: {}
+  status: {}
+- apiVersion: v1
+  groupNames:
+  - system:serviceaccounts:infographic-test
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:image-pullers
+    namespace: infographic-test
+  roleRef:
+    name: system:image-puller
+  subjects:
+  - kind: SystemGroup
+    name: system:serviceaccounts:infographic-test
+  userNames:
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:image-builders
+    namespace: infographic-test
+  roleRef:
+    name: system:image-builder
+  subjects:
+  - kind: ServiceAccount
+    name: builder
+  userNames:
+  - system:serviceaccount:infographic-test:builder
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:deployers
+    namespace: infographic-test
+  roleRef:
+    name: system:deployer
+  subjects:
+  - kind: ServiceAccount
+    name: deployer
+  userNames:
+  - system:serviceaccount:infographic-test:deployer
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: edit
+    namespace: infographic-test
+  roleRef:
+    name: edit
+  subjects:
+
+

--- a/templates/example/namespace/uat.yml
+++ b/templates/example/namespace/uat.yml
@@ -1,0 +1,67 @@
+---
+kind: List
+apiVersion: v1
+metadata: {}
+items:
+- apiVersion: v1
+  kind: ProjectRequest
+  metadata:
+    annotations:
+      openshift.io/description: ''
+      openshift.io/display-name: Infographic UAT
+    creationTimestamp:
+    name: infographic-uat
+  spec: {}
+  status: {}
+- apiVersion: v1
+  groupNames:
+  - system:serviceaccounts:infographic-uat
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:image-pullers
+    namespace: infographic-uat
+  roleRef:
+    name: system:image-puller
+  subjects:
+  - kind: SystemGroup
+    name: system:serviceaccounts:infographic-uat
+  userNames:
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:image-builders
+    namespace: infographic-uat
+  roleRef:
+    name: system:image-builder
+  subjects:
+  - kind: ServiceAccount
+    name: builder
+  userNames:
+  - system:serviceaccount:infographic-uat:builder
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: system:deployers
+    namespace: infographic-uat
+  roleRef:
+    name: system:deployer
+  subjects:
+  - kind: ServiceAccount
+    name: deployer
+  userNames:
+  - system:serviceaccount:infographic-uat:deployer
+- apiVersion: v1
+  groupNames:
+  kind: RoleBinding
+  metadata:
+    creationTimestamp:
+    name: edit
+    namespace: infographic-uat
+  roleRef:
+    name: edit
+  subjects:


### PR DESCRIPTION
…ing in deploy template

It makes more sense to have the Jenkins rolebinding in the deploy template since only the projects with deployments need it. 

Also, these example namespace templates weren't here originally, so adding these here, except changing them to ProjectRequest to allow non-cluster admins to run it. 