### PR TITLE
Removing logic limiting the FQDN/URL used for infographic app

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -32,49 +32,5 @@ describe('Util Tests', function() {
             result.should.be.a( 'string')
             result.should.equal( 'localhost:3000')
     	});
-
-    	it('should return correct dev backend url', function() {
-    		const url = 'http://web-infographic-dev.apps.env2-1.innovation.labs.redhat.com';
-            const result = lib.getBackendUrlBasedOnLocation( url );
-            result.should.be.a( 'string')
-            result.should.equal( 'http://node-app-infographic-dev.apps.env2-1.innovation.labs.redhat.com')
-    	});
-
-
-    	it('should return correct stage backend url', function() {
-    		const url = 'http://web-infographic-stage.apps.env2-1.innovation.labs.redhat.com';
-            const result = lib.getBackendUrlBasedOnLocation( url );
-            result.should.be.a( 'string')
-            result.should.equal( 'http://node-app-infographic-stage.apps.env2-1.innovation.labs.redhat.com')
-    	});
-
-    	it('should return correct prod backend url', function() {
-    		const url = 'http://web-infographic-prod.apps.env2-1.innovation.labs.redhat.com';
-            const result = lib.getBackendUrlBasedOnLocation( url );
-            result.should.be.a( 'string')
-            result.should.equal( 'http://node-app-infographic-prod.apps.env2-1.innovation.labs.redhat.com')
-    	});
-
-    	it('should return correct developer backend url', function() {
-    		const url = 'http://web-infographic-developerlastname.apps.env2-1.innovation.labs.redhat.com';
-            const result = lib.getBackendUrlBasedOnLocation( url );
-            result.should.be.a( 'string')
-            result.should.equal( 'http://node-app-infographic-developerlastname.apps.env2-1.innovation.labs.redhat.com')
-    	});
     });
-
-    describe('#getOpenShiftHostFromLocation()', function(){
-    	it('should return the correct OpenShift host from the location', function(){
-    		const result = lib.getOpenShiftHostFromHostName( 'web-infographic-dev.env3-1.innovation.labs.redhat.com' );
-    		result.should.be.a( 'string' )
-    		result.should.equals( '.env3-1.innovation.labs.redhat.com' )
-    	});
-
-    	it('should return empty for localhost', function(){
-    		const result = lib.getOpenShiftHostFromHostName( 'localhost:8080' );
-    		result.should.be.a( 'string' )
-    		expect( result ).to.be.empty
-    	});
-    });
-
 });

--- a/website/js/utils.js
+++ b/website/js/utils.js
@@ -16,30 +16,12 @@ function getBackendUrlBasedOnLocation( url ){
   const location = getLocation( url )
   
   if (location.hostname.includes('localhost') || location.hostname.includes('127.0.0.1')) {
-      return 'http://localhost:3000'
+    return 'http://localhost:3000'
   } else {
-      const result = location.hostname.match( /(infographic-[a-z]+)/g );
-      if ( result == null || result.length == 0 || result.length > 1 ){
-        return ''
-      } else {
-        return 'http://node-app-' + result[0] + getOpenShiftHostFromHostName( location.hostname );
-      }
-  }
-
-}
-
-
-function getOpenShiftHostFromHostName( hostName ){
-
-  const result = hostName.match(/(([.]{1})([a-z0-9\-]+))+/g);
-  if ( result == null || result.length == 0 || result.length > 1 ){
     return ''
-  } else {
-    return result[0]
   }
- 
+
 }
 
 exports.getBackendUrlBasedOnLocation = getBackendUrlBasedOnLocation
 exports.getLocation = getLocation
-exports.getOpenShiftHostFromHostName = getOpenShiftHostFromHostName


### PR DESCRIPTION
@mcanoy Would you mind reviewing this change. Basically eliminating the "forced" check on the URL to contain `infographic...` and otherwise hard-code it to use `http://node-app....` (and hence eliminated the `getOpenShiftHostFromHostName` function)

Also cleaned out dead test code referencing systems that no longer exists. 

@logandonley FYI ...