### PR TITLE
Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In OpenShift, the front end and back end are hosted as separate applications, us
 ## Important paths
 
 - `/index.html`: The public-facing infographic page. Clicking the "build" button takes the user to the Open Innovation Labs website.
-- `/internal.html`: The "internal" version of infographic. Clicking the "build" button kicks off an Ansible Tower job.
+- `/index.html?internal=true`: The "internal" version of infographic. Clicking the "build" button kicks off an Ansible Tower job.
 - `/stack`: The node.js API that the front end hits when the user clicks the "build" button. This API passes the request on to Ansible Tower.
 
 ## Icon conventions

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -1958,6 +1958,22 @@ ul.parsley-errors-list li {
   color: black;
 }
 
+.vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input.dirty[type="text"]:invalid {
+  border: 2px solid #bc202a;
+}
+
+.custom-error {
+  display: none;
+  color: #bc202a;
+  font-size: .875rem;
+  line-height: 1rem;
+  margin-bottom: .25rem;
+}
+
+.dirty:invalid + .custom-error {
+  display: block;
+}
+
 
 /* CONFIRMATION PAGE - Large and up */
 

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -173,6 +173,11 @@ form .block-section h3.block-section-header span {
     padding-left: 0px;
 }
 
+:last-child>.accordion-content:last-child {
+  border-bottom: none;
+}
+
+
 .accordion-item:first-child>:first-child,
 .accordion-item:last-child>:last-child {
     border-color: #D8DCDD;
@@ -471,11 +476,6 @@ label .checkbox-image,
     display: inline;
 }
 
-input[type='checkbox'] {
-    vertical-align: top;
-    margin-top: 3px;
-}
-
 label .checkbox-image {
     max-width: 110px;
     height: auto;
@@ -504,28 +504,10 @@ fieldset .row:not(:first-child) {
     display: none;
 }
 
-.locked {
-    content: '✔';
-}
-
 .btn-submit {
     text-transform: uppercase;
     background-color: transparent;
     border-color: transparent;
-}
-
-input#jenkins.locked {
-    background-color: #f0ab00;
-}
-
-input#rh-openshift-ent.locked,
-input#kubernetes.locked,
-input#docker.locked,
-input#cluster-metrics.locked,
-input#elasticsearch.locked,
-input#fluentd.locked,
-input#kibana.locked {
-    background-color: #1FBAE0;
 }
 
 a.active {
@@ -535,36 +517,6 @@ a.active {
 .locked + label .checkbox-image {
     position: relative;}
 
-.grayed-out {
-    display: none;
-}
-
-.grayed-out + label {
-    background: url('../images/gray.png') no-repeat;
-    height: 16px;
-    width: 16px;
-    display: inline-block;
-    padding: 0 0 0 0px;
-    background-size: cover;
-    left: -8px;
-    top: 3px;
-}
-
-.grayed-out:checked + label {
-    background: url('../images/gray.png') no-repeat;
-    height: 16px;
-    width: 16px;
-    display: inline-block;
-    padding: 0 0 0 0px;
-    background-size: cover;
-    left: -8px;
-    top: 3px;
-}
-
-.grayed-out + label .checkbox-image {
-    position: relative;
-    left: 25px;
-}
 
 #rhel {
     position: relative;
@@ -590,71 +542,68 @@ a.active {
 }
 
 input[type="checkbox"] {
-    -webkit-appearance: none;
+    position: absolute;
+    left: -9999px;
+    margin: 0;
     /* Hides the default checkbox style */
-    height: 1.5em;
-    width: 1.5em;
-    cursor: pointer;
-    position: relative;
-    -webkit-transition: .5s;
+}
+
+input[type="checkbox"] + label {
+  padding-left: 36px;
+  margin-left: 0;
+  cursor: pointer;
+  position: relative;
+
+}
+
+input[type="checkbox"] + label:before {
+  display: block;
+    position: absolute;
+    top: 3px;
+    left: 0;
+    width: 24px;
+    height: 24px;
+    line-height: 24px;
+    text-align: center;
+    color: #fff;
     background-color: #9F9F9F;
-}
-
-input[type="checkbox"]:before,
-input[type="checkbox"]:checked:before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    line-height: 1.5em;
-    text-align: center;
-    color: #fff;
     content: '—';
-    -webkit-transition: all 3s ease-in-out;
+    -webkit-transition: background-color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out;
 }
 
-input[type="checkbox"].locked:before,
-input[type="checkbox"].locked:checked:before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    line-height: 1.5em;
-    text-align: center;
-    color: #fff;
-    content: '✔';
-    -webkit-transition: all 3s ease-in-out;
+input.locked[type="checkbox"] + label:before {
+  background-color: #ddd;
+  content: '';
 }
 
-
-/*input[type="checkbox"]:before,*/
-
-input[type="checkbox"]:checked:before {
+input[type="checkbox"]:checked + label:before {
     content: '✔';
 }
 
-input[type="checkbox"].appdev-check:checked {
+input.appdev-check[type="checkbox"]:checked + label:before {
     background-color: #92d400;
 }
 
-input[type="checkbox"].devops-check:checked {
+input.devops-check[type="checkbox"]:checked + label:before {
     background-color: #f0ab00;
 }
 
-input[type="checkbox"].container-check:checked {
+input.container-check:checked[type="checkbox"] + label:before {
     background-color: #00b9e4;
 }
 
-input[type="checkbox"].iaas-check:checked {
+input.iaas-check:checked[type="checkbox"] + label:before {
     background-color: #3B0083;
+}
+
+input.container-check:checked[type="checkbox"] + label:before {
+  background-color: #1FBAE0;
 }
 
 input:focus {
     outline: none;
 }
-
 
 /* these exist in form but should not be visible on front end */
 

--- a/website/index.html
+++ b/website/index.html
@@ -348,7 +348,7 @@
                     <!-- B2.S1.Row 1 -->
                     <div class="row">
                       <div class="medium-3 columns last">
-                        <input id="jenkins" type="checkbox" value="true" name="jenkins" checked="checked" class="locked">
+                        <input id="jenkins" type="checkbox" value="true" name="jenkins" checked="checked" disabled="disabled" class="locked devops-check">
                         <label for="jenkins" data-tooltip data-template-classes="tooltip-devops" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Jenkins—a cross-platform, continuous integration and continuous delivery application that increases productivity."><img src="images/devops-tools/cont-int-cont-del/jenkins.png" class="checkbox-image" /></label>
                         <span class="text">Jenkins</span>
                       </div>
@@ -566,17 +566,17 @@
                       <!-- B3.S1.Row 1 -->
                       <div class="row">
                         <div class="medium-3 columns">
-                          <input id="rh-openshift-ent" type="checkbox" name="rh-openshift-ent" checked="checked" class="locked" value="true">
+                          <input id="rh-openshift-ent" type="checkbox" name="rh-openshift-ent" checked="checked" disabled="disabled" class="locked container-check" value="true">
                           <label for="rh-openshift-ent" data-tooltip data-template-classes="tooltip-container" data-template-classes="tooltip-container" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="OpenShift—an open source PaaS based on Docker containers and the Kubernetes container cluster manager for enterprise app development."><img src="images/container-platform/rhel/rh-openshift-ent.png" class="checkbox-image" /></label>
                           <span class="text">OpenShift</span>
                         </div>
                         <div class="medium-3 columns">
-                          <input id="kubernetes" type="checkbox" name="kubernetes" checked="checked" class="locked" value="true">
+                          <input id="kubernetes" type="checkbox" name="kubernetes" checked="checked" disabled="disabled" class="locked container-check" value="true">
                           <label for="kubernetes" data-tooltip data-template-classes="tooltip-container" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Kubernetes—an open source container cluster manager."><img src="images/container-platform/rhel/kubernetes.png" class="checkbox-image" /></label>
                           <span class="text">Kubernetes</span>
                         </div>
                         <div class="medium-3 columns end">
-                          <input id="docker" type="checkbox" name="docker" checked="checked" class="locked" value="true">
+                          <input id="docker" type="checkbox" name="docker" checked="checked" disabled="disabled" class="locked container-check" value="true">
                           <label for="docker" data-tooltip data-template-classes="tooltip-container" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Docker—an open platform for developers and system admins to build, ship, and run distributed applications on laptops, datacenter VMs, or in the cloud."><img src="images/container-platform/rhel/docker.png" class="checkbox-image" /></label>
                           <span class="text">Docker</span>
                         </div>
@@ -590,22 +590,22 @@
                       <!-- B3.S2.Row 1 -->
                       <div class="row">
                         <div class="medium-3 columns">
-                          <input id="cluster-metrics" type="checkbox" name="cluster-metrics" value="true" checked="checked" class="locked">
+                          <input id="cluster-metrics" type="checkbox" name="cluster-metrics" value="true" checked="checked"  disabled="disabled" class="locked container-check">
                           <label for="cluster-metrics" data-tooltip data-template-classes="tooltip-container" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Cluster Metrics—a way to centralize metrics collected in a node cluster, yielding a single metrics report. "><img src="images/container-platform/monitoring-logging/cluster-metrics.png" class="checkbox-image" /></label>
                           <span class="text">ClusterMetrics</span>
                         </div>
                         <div class="medium-3 columns">
-                          <input id="elasticsearch" type="checkbox" name="elasticsearch" value="true" checked="checked" class="locked">
+                          <input id="elasticsearch" type="checkbox" name="elasticsearch" value="true" checked="checked"  disabled="disabled" class="locked container-check">
                           <label for="elasticsearch" data-tooltip data-template-classes="tooltip-container" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="ElasticSearch—a distributed, open source search and analytics engine designed for horizontal scalability, reliability, and easy management."><img src="images/container-platform/monitoring-logging/elasticsearch.png" class="checkbox-image" /></label>
                           <span class="text">Elasticsearch</span>
                         </div>
                         <div class="medium-3 columns">
-                          <input id="fluentd" type="checkbox" name="fluentd" value="true" checked="checked" class="locked">
+                          <input id="fluentd" type="checkbox" name="fluentd" value="true" checked="checked" disabled="disabled" class="locked container-check">
                           <label for="fluentd" data-tooltip data-template-classes="tooltip-container" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Fluentd—an open source data collector that unifies data collection and consumption."><img src="images/container-platform/monitoring-logging/fluentd.png" class="checkbox-image" /></label>
                           <span class="text">Fluentd</span>
                         </div>
                         <div class="medium-3 columns">
-                          <input id="kibana" type="checkbox" name="kibana" value="true" checked="checked" class="locked">
+                          <input id="kibana" type="checkbox" name="kibana" value="true" checked="checked" disabled="disabled" class="locked container-check">
                           <label for="kibana" data-tooltip data-template-classes="tooltip-container" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Kibana—an open source data visualization platform that shows data graphically in combined custom dashboards."><img src="images/container-platform/monitoring-logging/kibana.png" class="checkbox-image" /></label>
                           <span class="text">Kibana</span>
                         </div>
@@ -613,7 +613,7 @@
                       <!-- B3.S2 Row 2 -->
                       <div class="row">
                         <div class="medium-3 columns end">
-                          <input id="sysdig" type="checkbox" name="sysdig" value="true">
+                          <input id="sysdig" type="checkbox" name="sysdig" value="true" class="container-check">
                           <label for="sysdig" data-tooltip data-template-classes="tooltip-container" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Sysdig—a unified approach to container security, monitoring, and forensics."><img src="images/container-platform/monitoring-logging/sysdig.png" class="checkbox-image" /></label>
                           <span class="text">Sysdig</span>
                         </div>
@@ -678,13 +678,6 @@
                         <label for="baremetal" data-tooltip data-template-classes="tooltip-iaas" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Bare metal server—a server that provides a non-virtualized compute infrastructure, meaning that unlike a public cloud, there is no hypervisor that creates virtual machines."><img src="images/iaas/private/baremetal.png" class="checkbox-image" /></label>
                         <span class="text">Bare Metal</span>
                       </div>
-                      <!--
-                      <div class="medium-3 columns">
-                      <input id="vmware" type="checkbox" class="iaas-check" name="vmware" checked="checked" class="grayed-out" value="true">
-                      <label for="vmware" data-tooltip data-template-classes="tooltip-iaas"  aria-haspopup="true" class="has-tip" data-disable-hover="false" title="VMware—software that lets you quickly, seamlessly, and securely extend your datacenter into the cloud using the tools and processes you already have."><img src="images/iaas/private/vmware.png" class="checkbox-image" /></label>
-                      <span class="text">VMWare</span>
-                    </div>
-                  -->
                 </div>
               </fieldset>
             </span>
@@ -724,12 +717,12 @@
                 <!-- B4.S4.Row 1 -->
                 <div class="row">
                   <div class="medium-3 columns">
-                    <input id="rh-satellite" type="checkbox" name="rh-satellite" checked="checked" class="locked custom-checkbox" value="true">
+                    <input id="rh-satellite" type="checkbox" name="rh-satellite" checked="checked" disabled="disabled" class="locked custom-checkbox" value="true">
                     <label for="rh-satellite" data-tooltip data-template-classes="tooltip-iaas"  aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Red Hat Satellite—an open source systems management product that allows system administrators to deploy, manage, and monitor Red Hat Enterprise Linux® and Solaris hosts."><img src="images/iaas/management/rh-satellite.png" class="checkbox-image" /> </label>
                     <span class="text">Red Hat Satellite</span>
                   </div>
                   <div class="medium-3 columns end">
-                    <input id="rh-cloudforms" type="checkbox" name="rh-cloudforms" checked="checked" class="locked" value="true">
+                    <input id="rh-cloudforms" type="checkbox" name="rh-cloudforms" checked="checked" disabled="disabled" class="locked" value="true">
                     <label for="rh-cloudforms" data-tooltip data-template-classes="tooltip-iaas" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Red Hat CloudForms—a hybrid cloud management product that manages private clouds, virtual environments, and public clouds all with one interface. "><img src="images/iaas/management/rh-cloudforms.png" class="checkbox-image" /></label>
                     <span class="text">Red Hat CloudForms</span>
                   </div>
@@ -743,7 +736,7 @@
                 <!-- B4.S4.Row 1 -->
                 <div class="row">
                   <div class="medium-3 columns end">
-                    <input id="open-vswitch" type="checkbox" name="open-vswitch" checked="checked" class="locked" value="true">
+                    <input id="open-vswitch" type="checkbox" name="open-vswitch" checked="checked" disabled="disabled" class="locked" value="true">
                     <label for="open-vswitch" data-tooltip data-template-classes="tooltip-iaas"  aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Open vSwitch (OVS)—a production-quality open-source implementation of a distributed virtual multilayer switch."><img src="images/iaas/networking/open-vswitch.png" class="checkbox-image" /></label>
                     <span class="text">Open vSwitch</span>
                   </div>
@@ -757,12 +750,12 @@
                 <!-- B4.S5.Row 1 -->
                 <div class="row">
                   <div class="medium-3 columns">
-                    <input id="rh-gluster-storage" type="checkbox" name="rh-gluster-storage" checked="checked" class="locked" value="true">
+                    <input id="rh-gluster-storage" type="checkbox" name="rh-gluster-storage" checked="checked" disabled="disabled" class="locked" value="true">
                     <label for="rh-gluster-storage" data-tooltip data-template-classes="tooltip-iaas"  aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Red Hat Gluster Storage—an open source product that lets you easily manage a continuous storage platform for physical, virtual, and cloud resources."><img src="images/iaas/storage/rh-gluster-storage.png" class="checkbox-image" /></label>
                     <span class="text">Red Hat Gluster Storage</span>
                   </div>
                   <div class="medium-3 columns end">
-                    <input id="rh-ceph-storage" type="checkbox" name="rh-ceph-storage" checked="checked" class="locked" value="true">
+                    <input id="rh-ceph-storage" type="checkbox" name="rh-ceph-storage" checked="checked" disabled="disabled" class="locked" value="true">
                     <label for="rh-ceph-storage" data-tooltip data-template-classes="tooltip-iaas" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Red Hat Ceph Storage—an open source product of software-defined storage that flexibly and affordably manages data growth by storing data in the cloud."><img src="images/iaas/storage/rh-ceph-storage.png" class="checkbox-image" /></label>
                     <span class="text">Red Hat Ceph Storage</span>
                   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -693,8 +693,8 @@
                 <!-- B4.S3.Row 1 -->
                 <div class="row">
                   <div class="medium-3 columns">
-                    <label for="aws" data-tooltip data-template-classes="tooltip-iaas"  aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Amazon WebServices (AWS)—an on-demand computing platform that offers a suite of cloud computing services."><img src="images/iaas/public/aws.png" class="checkbox-image" /></label>
                     <input id="aws" type="checkbox" class="iaas-check" name="public-cloud" value="aws" data-parsley-maxcheck="1" data-parsley-errors-container=".error-container" data-parsley-error-message="Please choose only one public cloud provider.">
+                    <label for="aws" data-tooltip data-template-classes="tooltip-iaas"  aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Amazon WebServices (AWS)—an on-demand computing platform that offers a suite of cloud computing services."><img src="images/iaas/public/aws.png" class="checkbox-image" /></label>
                     <span class="text">Amazon Web Services</span>
                   </div>
                   <div class="medium-3 columns">

--- a/website/index.html
+++ b/website/index.html
@@ -938,7 +938,6 @@
           <div class="arrow_box" id="arrowBox">
             <input class="btn-submit" type="submit" name="submit" value="Submit">
           </div>
-          <!--<button type="submit"  >Submit</button>-->
           <div class="error-container"></div>
         </div>
       </div>

--- a/website/index.html
+++ b/website/index.html
@@ -17,6 +17,8 @@
   <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/jquery.jssocials/1.2.1/jssocials.css" />
   <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/jquery.jssocials/1.2.1/jssocials-theme-flat.css" />
   <link rel="stylesheet" href="css/app.css" type="text/css">
+  <link rel="stylesheet" href="css/vex.css" type="text/css">
+  <link rel="stylesheet" href="css/vex-theme-plain.css" type="text/css">
 </head>
 
 <body id="tech-stack">
@@ -1468,6 +1470,7 @@ CONFIRMATION PAGE BELOW
     <script type="text/javascript" src="js/vendor/jssocials.js"></script>
     <script src="js/vendor/html2canvas.js"></script>
     <script src="js/vendor/matchHeight.js"></script>
+    <script src="js/vendor/vex.combined.min.js"></script>
     <script src="js/app.js"></script>
   </body>
 

--- a/website/index.html
+++ b/website/index.html
@@ -1324,7 +1324,7 @@ CONFIRMATION PAGE BELOW
                       <h3>Managed Services</h3>
                     </div>
                     <div>
-                      <img src="images/iaas/managed/openshift-dedicated.png" class="openshift-dedicated" />
+                      <img src="images/iaas/managed/openshift-dedicated-print-grey.png" class="openshift-dedicated" />
                     </div>
                   </div>
                   <div class="conf-section thin-border-right" id="private-conf">

--- a/website/internal.html
+++ b/website/internal.html
@@ -1,16 +1,31 @@
-
-    <link rel="stylesheet" href="css/app.css" type="text/css">
-    <link rel="stylesheet" href="css/vex.css" type="text/css">
-    <link rel="stylesheet" href="css/vex-theme-plain.css" type="text/css">
-    <script src="js/vendor/jquery.js"></script>
-    <script src="js/vendor/vex.combined.min.js"></script>
-    <script>
-    window.rhtLabsInternal = true;
-    $(function(){
-      $("#includedContent").load("index.html");
-    });
-
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    <script type="text/javascript">
+      // If the old internal.html page is used instead of the new "?internal"
+      // query string, remove "internal.html", add the "?internal" flag, and
+      // persist any existing query string.
+      (function(){
+        var location = window.location.href;
+        // Use an empty string instead of index.html because in the Drupal version
+        // of this page, index.html isn't available.
+        location = location.replace('internal.html', '');
+        if (location.indexOf('internal=true') !== -1) {
+          window.location = location;
+          return;
+        }
+        if (location.indexOf('?') === -1) {
+          location += '?'
+        } else {
+          location += '&'
+        }
+        location += 'internal=true';
+        window.location = location;
+      })();
     </script>
-
-    <div id="includedContent">
-    </div>
+  </body>
+</html>

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -3,6 +3,13 @@ $(document).ready(function() {
     // init foundation
     $(document).foundation()
 
+    // If this flag is set, allow the user to kick off an Ansible job
+    window.rhtLabsInternal = (getQueryVariable('internal') === 'true');
+    if (window.rhtLabsInternal) {
+      // Persist internal flag when form is submitted.
+      $('#form').append('<input type="hidden" name="internal" value="true" />');
+    }
+
     var docWidth = $(document).width();
     console.log(docWidth);
 
@@ -166,7 +173,6 @@ $(document).ready(function() {
     })
 
 });
-
 
 function getQueryVariable(variable) {
     var query = window.location.search.substring(1);

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -367,6 +367,7 @@ function callStack(projName, username, gitRepo) {
                 '<label for="projectName">Project Name</label>',
                 '<input type="text" name="projectName" id="projectName" value="' + projName + '"\
                   required pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?" />',
+                '<span class="custom-error">Project name is required and must contain only lowercase letters, numbers, and dashes.</span>',
                 '<label for="username">Username</label>',
                 '<input type="text" name="username" id="username" value="' + username + '" required/>',
                 '<label for="password">Password</label>',
@@ -393,12 +394,16 @@ function callStack(projName, username, gitRepo) {
                 }
             }
         });
-        $('#projectName').on('input', function() {
-          this.setCustomValidity('');
-          if (!this.validity.valid && this.value !== '') {
-            this.setCustomValidity('Please use only lowercase letters, numbers, and dashes.');
-          }
-        });
+        $('#projectName')
+          .on('input', function() {
+            this.setCustomValidity('');
+            if (!this.validity.valid && this.value !== '') {
+              this.setCustomValidity('Please use only lowercase letters, numbers, and dashes.');
+            }
+          })
+          .on('blur', function() {
+            $(this).addClass('dirty');
+          });
     } else {
         console.log('redirecting');
         window.location = 'https://www.redhat.com/en/explore/open-innovation-labs';

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -369,7 +369,8 @@ function callStack(projName, username, gitRepo) {
             input: [
                 '<fieldset>',
                 '<label for="projectName">Project Name</label>',
-                '<input type="text" name="projectName" id="projectName" value="' + projName + '" required/>',
+                '<input type="text" name="projectName" id="projectName" value="' + projName + '"\
+                  required pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?" />',
                 '<label for="username">Username</label>',
                 '<input type="text" name="username" id="username" value="' + username + '" required/>',
                 '<label for="password">Password</label>',
@@ -395,6 +396,12 @@ function callStack(projName, username, gitRepo) {
                         vex.dialog.alert({ className: 'vex-theme-plain', unsafeMessage: "<div class='vex-labs-alert'>Failed: " + message + '</div>'})});
                 }
             }
+        });
+        $('#projectName').on('input', function() {
+          this.setCustomValidity('');
+          if (!this.validity.valid && this.value !== '') {
+            this.setCustomValidity('Please use only lowercase letters, numbers, and dashes.');
+          }
         });
     } else {
         console.log('redirecting');

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -406,7 +406,3 @@ function callStack(projName, username, gitRepo) {
 
     return false;
 }
-
-if (window.rhtLabsInternal){
-    $("#form").attr("action", 'internal.html');
-}

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -77,11 +77,6 @@ $(document).ready(function() {
     // show and hide sidebar selections based on checkbox selections
     $('input:checkbox').on('change', function(e) {
         var $this = $(this);
-        if ($this.hasClass('locked') || $this.hasClass('grayed-out')) {
-            // this item is locked - do nothing
-            e.preventDefault();
-            return;
-        }
         // toggle item in the sidebar
         var $elToChange = $( '.' + $this.attr('id') );
         if ( $this.prop('checked') ) {
@@ -97,10 +92,13 @@ $(document).ready(function() {
       if ( $('#openshift-dedicated').prop('checked') ) {
         $privateChecks
           .prop('checked', false)
-          .change()
-          .addClass('grayed-out');
+          .prop('disabled', true)
+          .addClass('locked')
+          .change();
       } else {
-        $privateChecks.removeClass('grayed-out');
+        $privateChecks
+          .removeClass('locked')
+          .prop('disabled', false);
       }
     }
     // Call the function on init in case the checkbox is already checked
@@ -224,25 +222,7 @@ function buildSidebar() {
         var lockedIcon = '<img src="images/lock.png" class="locked-icon" />'
         $('tr.' + tableRowToShow + ' td.remove').html(lockedIcon);
     });
-
-    // show grayed out forms items dynamically in sidebar w/ gray icon
-    $('input.grayed-out').each(function() {
-
-        // show the table row
-        var tableRowToShow = $(this).attr('id');
-        $('tr.' + tableRowToShow).show();
-
-        // replace the remove option with gray icon
-        var grayIcon = '<img src="images/gray.png" class="locked-icon" />'
-        $('tr.' + tableRowToShow + ' td.remove').html(grayIcon);
-    });
-
 }
-
-
-
-
-
 
 function buildConfirmationPage() {
 

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -67,8 +67,18 @@ $(document).ready(function() {
     });
 
     // init parsley
-    $('#form').parsley();
-
+    (function() {
+      var $errorContainer = $('.error-container');
+      var $page = $('html, body');
+      var errorOffset = 20;
+      $('#form')
+        .parsley()
+        .on('field:error', function() {
+          $page.animate({
+            scrollTop: $errorContainer.position().top - errorOffset
+          }, 300);
+        });
+    })();
 
     // dynamically build sidebar based on form HTML
     buildSidebar();


### PR DESCRIPTION
- On the reference diagram, OpenShift dedicated is now greyed out if it's not selected.
- Validate project name in the UI - only lowercase letters, numbers, and dashes are allowed.
- Fix Ansible logo on reference diagram. (In Chrome, this would sporadically fail to appear.)
- Make styled checkboxes work on browsers other than Chrome and Safari.
- When a validation error occurs, scroll the error message into view so that the user knows what happened.
- Improve performance of the "internal" version of the page.
- Consolidate confusing "locked" and "grayed out" states into one "locked" state. (This is an internal code tweak; the checkboxes themselves look the same.)

The Chrome + Ansible logo bug was a race condition. `internal.html` loads content from `index.html`, and if the JavaScript layout code runs before the content has finished loading, layout problems appear. To fix that problem, I switched to using index.html for both versions of the page and accessing the "internal" version of the page via a query string (e.g. `localhost:8080/?internal=true`). There's still an `internal.html` file, but it's there solely to redirect old URLs to their new equivalents.

resolves #25 

@oybed, do these changes look okay to you?
CC @mwalker5000 
