### PR TITLE
Add RHAMT

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -693,8 +693,8 @@
                 <!-- B4.S3.Row 1 -->
                 <div class="row">
                   <div class="medium-3 columns">
-                    <label for="aws" data-tooltip data-template-classes="tooltip-iaas"  aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Amazon WebServices (AWS)—an on-demand computing platform that offers a suite of cloud computing services."><img src="images/iaas/public/aws.png" class="checkbox-image" /></label>
                     <input id="aws" type="checkbox" class="iaas-check" name="public-cloud" value="aws" data-parsley-maxcheck="1" data-parsley-errors-container=".error-container" data-parsley-error-message="Please choose only one public cloud provider.">
+                    <label for="aws" data-tooltip data-template-classes="tooltip-iaas"  aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Amazon WebServices (AWS)—an on-demand computing platform that offers a suite of cloud computing services."><img src="images/iaas/public/aws.png" class="checkbox-image" /></label>
                     <span class="text">Amazon Web Services</span>
                   </div>
                   <div class="medium-3 columns">

--- a/website/index.html
+++ b/website/index.html
@@ -103,6 +103,14 @@
                         <span class="text">Red Hat JBoss Web Server</span>
                       </div>
                     </div>
+                    <!-- B1.S1.Row 3 -->
+                    <div class="row">
+                      <div class="medium-3 columns end">
+                        <input id="rhamt" type="checkbox" class="appdev-check" value="true" name="rhamt">
+                        <label for="rhamt" data-tooltip data-template-classes="tooltip-appdev" aria-haspopup="true" class="has-tip" data-disable-hover="false" title="Red Hat Application Application Migration Toolkit—enable large-scale application migrations and modernizations."><img src="images/application-development/rhe-os/rhamt.png" class="checkbox-image" /></label>
+                        <span class="text">Red Hat Application Migration Toolkit</span>
+                      </div>
+                    </div>
                   </fieldset>
                 </span>
                 <!--BLOCK 1 SECTION 2  -->
@@ -1010,8 +1018,8 @@ CONFIRMATION PAGE BELOW
                 <div>
                   <!--2 images across-->
                   <img src="images/application-development/rhe-os/rhoar-print-grey.png" class="rhoar">
-                  <img src="images/application-development/rhe-os/rhjb-brms-print-grey.png" class="rhjb-brms" />
                   <img src="images/application-development/rhe-os/rhjb-amq-print-grey.png" class="rhjb-amq" />
+                  <img src="images/application-development/rhe-os/rhjb-brms-print-grey.png" class="rhjb-brms" />
                 </div>
                 <!--2 images across-->
                 <div>
@@ -1020,8 +1028,9 @@ CONFIRMATION PAGE BELOW
                   <img src="images/application-development/rhe-os/rhjb-fuse-print-grey.png" class="rhjb-fuse" />
                 </div>
                 <div>
-                  <img src="images/application-development/rhe-os/rhjb-webserver-print-grey.png" class="rhjb-webserver" />
                   <img src="images/application-development/rhe-os/rh-map-print-grey.png" class="rh-map" />
+                  <img src="images/application-development/rhe-os/rhjb-webserver-print-grey.png" class="rhjb-webserver" />
+                  <img src="images/application-development/rhe-os/rhamt-print-grey.png" class="rhamt" />
                 </div>
               </div>
               <!-- close conf-section -->


### PR DESCRIPTION
- Add Red Hat Application Migration Toolkit icon
- Fix order of RH Open Source icons in reference - the order now matches the order of the corresponding icons on the main page.

Resolves #28.