### PR TITLE
Removing build triggers to let Jenkins take full control

### DIFF
--- a/templates/build/template-build.yml
+++ b/templates/build/template-build.yml
@@ -64,10 +64,6 @@ objects:
     labels:
       application: "${APPLICATION_NAME}"
   spec:
-    triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChange: {}
     source:
       type: Git
       git:


### PR DESCRIPTION
When Jenkins is controlling the build, we should disable the OpenShift triggers as otherwise we'll get 2 builds on the initial deployment. This PR removes the triggers that will kick off the OpenShift build before Jenkins does. 