### PR TITLE
Updating API version on stack.js

### DIFF
--- a/lib/stack.js
+++ b/lib/stack.js
@@ -88,8 +88,8 @@ function sendTowerRequest(params, cb){
 		json: config_body
 	};
 
-	// options_string = JSON.stringify(options, null, 4);
-	// console.log('calling options: ' + options_string);
+	options_string = JSON.stringify(options, null, 4);
+	console.log('calling options: ' + options_string);
 
 	request(options, function (error, response) {
 		// console.log('*********RESPONSE**********************');

--- a/lib/stack.js
+++ b/lib/stack.js
@@ -10,7 +10,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
 
 
 function getTemplateLaunchUri(){
-	return '/api/v1/job_templates/' + AnsibleTowerTemplateId + '/launch/';
+	return '/api/v2/job_templates/' + AnsibleTowerTemplateId + '/launch/';
 }
 
 
@@ -88,8 +88,8 @@ function sendTowerRequest(params, cb){
 		json: config_body
 	};
 
-	options_string = JSON.stringify(options, null, 4);
-	console.log('calling options: ' + options_string);
+	// options_string = JSON.stringify(options, null, 4);
+	// console.log('calling options: ' + options_string);
 
 	request(options, function (error, response) {
 		// console.log('*********RESPONSE**********************');


### PR DESCRIPTION
**What does this PR do?**
This PR updates the api call that the infographic app uses to communicate with Ansible Tower and kick off the desired job. As the latest version of Ansible Tower no longer uses api v1, this url is reported as incorrect by the Infographic app while trying to launch the template job.

**How should this be tested?**
This can be tested by using Ansible Tower API console by pointing out to the following url 'https://tower-url/api/v2', and the information about REST APIv2 should appear rather than the 'The requested resource could not be found' error message.

**Is there a relevant Issue open for this?**
N/A

**Other Relevant info, PRs, etc.**
N/A

People to notify
cc: @redhat-cop/rht-labs