### PR TITLE
Moving images, fonts and js to absolute path for redhat.com

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -14,12 +14,16 @@
   <title>My Open Innovation Labs Technology Stack</title>
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;700&family=Red+Hat+Text:wght@400;700&display=swap" rel="stylesheet"> 
-  <link rel="stylesheet" href="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/css/foundation.min.css">
+  <!--
+    Using 'http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/' will source CSS and JS from this GitHub repo/branch, 
+    e.g.: from 'https://github.com/rht-labs/infographic/tree/redhat.com' - in essence the same as using `raw.githubusercontent.com` URLs (which doesn't work for CSS and JS)
+  -->
+  <link rel="stylesheet" href="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/css/foundation.min.css">
   <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/jquery.jssocials/1.2.1/jssocials.css" />
   <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/jquery.jssocials/1.2.1/jssocials-theme-flat.css" />
-  <link rel="stylesheet" href="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/css/app.css" type="text/css">
-  <link rel="stylesheet" href="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/css/vex.css" type="text/css">
-  <link rel="stylesheet" href="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/css/vex-theme-plain.css" type="text/css">
+  <link rel="stylesheet" href="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/css/app.css" type="text/css">
+  <link rel="stylesheet" href="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/css/vex.css" type="text/css">
+  <link rel="stylesheet" href="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/css/vex-theme-plain.css" type="text/css">
 </head>
 
 <body>
@@ -1698,16 +1702,21 @@
       </div>
       <!-- end html2canvas -->
   </div><!-- end #tech-stack -->
+
+  <!--
+    Using 'http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/' will source CSS and JS from this GitHub repo/branch, 
+    e.g.: from 'https://github.com/rht-labs/infographic/tree/redhat.com' - in essence the same as using `raw.githubusercontent.com` URLs (which doesn't work for CSS and JS)
+  -->
   <script src="https://use.fontawesome.com/4e2c0cebba.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/jquery.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/what-input.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/foundation.min.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/jquery-ui.min.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/parsley.min.js"></script>
-  <script type="text/javascript" src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/jssocials.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/html2canvas.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/matchHeight.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/vendor/vex.combined.min.js"></script>
-  <script src="https://raw.githubusercontent.com/rht-labs/infographic/redhat.com/website/js/app.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/jquery.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/what-input.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/foundation.min.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/jquery-ui.min.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/parsley.min.js"></script>
+  <script type="text/javascript" src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/jssocials.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/html2canvas.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/matchHeight.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/vendor/vex.combined.min.js"></script>
+  <script src="http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/website/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Using 'http://cdn.jsdelivr.net/gh/rht-labs/infographic@redhat.com/' will source CSS and JS from this GitHub repo/branch, e.g.: from 'https://github.com/rht-labs/infographic/tree/redhat.com' - in essence the same as using `raw.githubusercontent.com` URLs (which doesn't work for CSS and JS) 